### PR TITLE
Feat: respect defined args to allow focused combinations

### DIFF
--- a/src/getCombinations.ts
+++ b/src/getCombinations.ts
@@ -1,15 +1,8 @@
 import { Args, ArgTypes } from "@storybook/addons";
-// @ts-expect-error
 import cartesian from "cartesian";
 
-type ArgsMap = {
-  [argName: string]: unknown;
-};
-
-type Combinations = Array<Args>;
-
-export function getCombinations(argTypes: ArgTypes) {
-  const argsMap: ArgsMap = {};
+export function getCombinations(argTypes: ArgTypes, args: Args) {
+  const argsMap: Args = {};
 
   // args order can change in stories, sorting ensures grid items don't jump between story previews.
   const sortedArgTypes = [...Object.entries(argTypes)].sort(
@@ -19,17 +12,31 @@ export function getCombinations(argTypes: ArgTypes) {
   );
 
   sortedArgTypes.forEach(([argName, argData]) => {
+    // If args are provided, use them.
+    if (args[argName] !== undefined) {
+      argsMap[argName] = args[argName];
+      return;
+    }
+
+    if (!argData.type) {
+      return;
+    }
+
     // @ts-expect-error
     const { name: typeName, value } = argData.type;
     if (!["enum", "boolean"].includes(typeName)) {
       return;
     }
 
-    const values = typeName === "boolean" ? [true, false] : value;
-    argsMap[argName] = values;
+    if (typeName === "boolean") {
+      argsMap[argName] = [true, false];
+      return;
+    }
+
+    argsMap[argName] = value;
   });
 
-  const combinations = cartesian(argsMap) as Combinations;
+  const combinations = cartesian(argsMap);
 
   return combinations;
 }

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,1 +1,5 @@
 declare module "global";
+
+declare module "cartesian" {
+  export default function cartesian<T>(obj: T | T[]): T[];
+}

--- a/src/withVariants.tsx
+++ b/src/withVariants.tsx
@@ -25,8 +25,8 @@ interface CombinationGridProps {
 
 function CombinationGrid({ StoryFn, context }: CombinationGridProps) {
   const combinations = useMemo(
-    () => getCombinations(context.argTypes),
-    [context.argTypes]
+    () => getCombinations(context.argTypes, context.args),
+    [context.argTypes, context.args]
   );
 
   if (combinations.length === 0) {

--- a/stories/Button.stories.tsx
+++ b/stories/Button.stories.tsx
@@ -19,6 +19,8 @@ export default {
 
 const Template = (args) => <Button {...args} />;
 
+export const AllVariants = Template.bind({});
+
 export const Primary = Template.bind({});
 Primary.args = {
   outline: false,
@@ -38,5 +40,3 @@ export const Small = Template.bind({});
 Small.args = {
   size: "small",
 };
-
-export const AllVariants = Template.bind({});

--- a/stories/Button.stories.tsx
+++ b/stories/Button.stories.tsx
@@ -5,8 +5,12 @@ export default {
   title: "Example/Button",
   component: Button,
   args: {
-    ...Button.defaultProps,
     children: "My Button",
+  },
+  argTypes: {
+    children: {
+      control: 'text'
+    },
   },
   parameters: {
     layout: 'centered',
@@ -16,6 +20,9 @@ export default {
 const Template = (args) => <Button {...args} />;
 
 export const Primary = Template.bind({});
+Primary.args = {
+  outline: false,
+}
 
 export const Outline = Template.bind({});
 Outline.args = {
@@ -31,3 +38,5 @@ export const Small = Template.bind({});
 Small.args = {
   size: "small",
 };
+
+export const AllVariants = Template.bind({});


### PR DESCRIPTION
Hey @itaditya! I love this addon so much! I was experimenting with something very similar recently but your implementation is much better <3

With this PR I'm suggesting it should respect args passed to a story, this way you allow for a focused combination per story, where you see, for instance, all combinations for the primary state, then all combinations for secondary, etc.

**Before:**
![2022-06-26 12 59 34](https://user-images.githubusercontent.com/1671563/175811038-2d8ba40a-6d78-4efd-adea-0fdb08171a93.gif)

**After:**
![2022-06-26 12 55 05](https://user-images.githubusercontent.com/1671563/175810910-7eb7f0fd-e1b3-4c50-8fec-b68a444d1458.gif)

The caveat here is that with this change, in order to get the "all possible variants" experience, users would have to not pass any args to the story.

I assume in the future this addon might have some possible options for different things, so maybe this behavior could be opt-in (or opt-out) via a parameter like:

```js
MyStory.parameters = {
  variants: {
    respectArgs: false
  }
}
```

I hope you like it!