### PR TITLE
docs(README): remove unnecessary /preset from instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ Show all variants of a component in a grid
 npm install storybook-addon-variants
 ```
 
-#### And lastly, register the preset
+#### And lastly, register the addon
 
 ```js
 // .storybook/main.js
 
 module.exports = {
   stories: [...],
-  addons: ["storybook-addon-variants/preset.js"],
+  addons: ["storybook-addon-variants"],
 };
 
 ```


### PR DESCRIPTION
This PR removes the `/preset` from the addon name in the instructions.

This is not necessary anymore in Storybook, it find that file automatically.
